### PR TITLE
Bump dependencies to solve casing related npm install issues with JSONpath

### DIFF
--- a/lib/rest-builder.js
+++ b/lib/rest-builder.js
@@ -16,7 +16,7 @@ var JsonTemplate = require('./template');
 
 var jsonPath = null;
 try {
-  jsonPath = require('JSONPath');
+  jsonPath = require('jsonpath-plus');
 } catch (err) {
   // Ignore
 }
@@ -548,7 +548,7 @@ RequestBuilder.prototype.invoke = function (parameters, cb) {
   var callback = cb;
   var self = this;
   if (cb) {
-    callback = function (err, response, body) {
+    callback = function(err, response, body) {
       if (err) {
         if (debug.enabled) {
           debug('Error Response: %j', err);
@@ -557,7 +557,11 @@ RequestBuilder.prototype.invoke = function (parameters, cb) {
       } else {
         var result = body;
         if (jsonPath && self.template.template.responsePath) {
-          result = jsonPath.eval(body, self.template.template.responsePath);
+          result = jsonPath({
+            wrap: true,
+            json: body,
+            path: self.template.template.responsePath,
+          });
         }
         if (debug.enabled) {
           debug('Response: %j', result);

--- a/package.json
+++ b/package.json
@@ -16,21 +16,21 @@
   "dependencies": {
     "debug": "^2.1.1",
     "jsonpath-plus": "^0.14.0",
-    "lodash": "^3.2.0",
+    "lodash": "^4.6.1",
     "methods": "^1.1.1",
     "mime": "^1.3.4",
-    "qs": "^2.3.3",
+    "qs": "^6.1.0",
     "request": "^2.53.0",
     "traverse": "^0.6.6"
   },
   "devDependencies": {
-    "bluebird": "^2.9.24",
+    "bluebird": "^3.3.4",
     "body-parser": "^1.12.0",
     "express": "^4.12.0",
     "loopback": "2.x.x",
     "loopback-datasource-juggler": "2.x.x",
     "mocha": "^2.1.0",
-    "should": "^5.0.1"
+    "should": "^8.2.2"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-connector-rest",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "Loopback REST Connector",
   "keywords": [
     "StrongLoop",

--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
     "test": "./node_modules/.bin/mocha --timeout 30000 test/*test.js"
   },
   "dependencies": {
+    "debug": "^2.1.1",
+    "jsonpath-plus": "^0.14.0",
     "lodash": "^3.2.0",
-    "request": "^2.53.0",
-    "qs": "^2.3.3",
-    "mime": "^1.3.4",
     "methods": "^1.1.1",
-    "traverse": "^0.6.6",
-    "JSONPath": "^0.10.0",
-    "debug": "^2.1.1"
+    "mime": "^1.3.4",
+    "qs": "^2.3.3",
+    "request": "^2.53.0",
+    "traverse": "^0.6.6"
   },
   "devDependencies": {
     "bluebird": "^2.9.24",


### PR DESCRIPTION
Cherry-picked changes from https://github.com/strongloop/loopback-connector-rest/pull/55
